### PR TITLE
Update Lustre URL to point to el7 symlink

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -769,7 +769,7 @@ def setup_network_storage():
             util.run("sudo yum install -y cifs-utils")
             cifs_installed = True
         elif fs_type == 'lustre' and not lustre_path.exists():
-            lustre_url = 'https://downloads.whamcloud.com/public/lustre/latest-release/el7.7.1908/client/RPMS/x86_64/'
+            lustre_url = 'https://downloads.whamcloud.com/public/lustre/latest-release/el7/client/RPMS/x86_64/'
             lustre_tmp = Path('/tmp/lustre')
             lustre_tmp.mkdir(parents=True)
             util.run('sudo yum update -y')


### PR DESCRIPTION
The old version is no longer available. Instead of referening the
new minor number just reference the top level el7 symlink for the
url.

TEST: Deploy lustre with slurm-gcp