### PR TITLE
Fix missing bandwidth_tier into io.tf Singularity example v4

### DIFF
--- a/tf/examples/singularity/io.tf
+++ b/tf/examples/singularity/io.tf
@@ -245,6 +245,7 @@ variable "partitions" {
     regional_capacity    = bool,
     regional_policy      = any,
     instance_template    = string,
+    bandwidth_tier       = string,
   static_node_count = number }))
 }
 


### PR DESCRIPTION
`bandwidth_tier` is missing on the `partition` variable of the `singularity` example `v4` module.  As a result, the following error comes up:

```
╷
│ Error: Invalid value for input variable
│ 
│   on main.tf line 35, in module "slurm_cluster_network":
│   35:   partitions                    = var.partitions
│ 
│ The given value is not suitable for
│ module.slurm_cluster_network.var.partitions declared at
│ ../../modules/network/io.tf:70,1-22: incorrect list element type: attribute
│ "bandwidth_tier" is required.
╵
╷
│ Error: Invalid value for input variable
│ 
│   on main.tf line 62, in module "slurm_cluster_controller":
│   62:   partitions                    = var.partitions
│ 
│ The given value is not suitable for
│ module.slurm_cluster_controller.var.partitions declared at
│ ../../modules/controller/io.tf:149,1-22: incorrect list element type:
│ attribute "bandwidth_tier" is required.
╵
╷
│ Error: Invalid value for input variable
│ 
│   on main.tf line 113, in module "slurm_cluster_compute":
│  113:   partitions                 = var.partitions
│ 
│ The given value is not suitable for
│ module.slurm_cluster_compute.var.partitions declared at
│ ../../modules/compute/io.tf:59,1-22: incorrect list element type: attribute
│ "bandwidth_tier" is required.
╵
ERRO[0037] 1 error occurred:
        * exit status 1
```